### PR TITLE
Merging changes to glaive rush and to add regulation c sets

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                 </div>
             </div>
             <div class="main-result-group">
-                <div class="big-text"><span id="mainResult">Loading...</span></div>
+                <div class="big-text"><span id="mainResult" onclick="Clipboard_CopyTo(this.textContent)" title="Click to copy the result.">Loading...</span></div>
                 <div class="small-text"><span id="damageValues">(If you see this message for more than a few seconds, try enabling JavaScript. If you have that enabled, try deleting your cookies. Otherwise, I won't be able to help you unless you send a screenshot of your browser console [Ctrl+Shift+I on Google Chrome].)</span></div>
             </div>
             <div class="panel poke-info" id="p1">
@@ -233,7 +233,7 @@
                         <select class="move-10hits calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option><option value="6">6 hits</option><option value="7">7 hits</option><option value="8">8 hits</option><option value="9">9 hits</option><option value="10">10 hits</option></select>
                         <select class="move-lastRespRageFist calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
                     </div>
-                    <!--<input class="glaive-rush calc-trigger hide" type="checkbox" id="glaiveL" title="Apply double damage from using Glaive Rush?" />-->
+                    <input class="glaive-rush calc-trigger hide" type="checkbox" id="glaiveL" title="Apply double damage from using Glaive Rush?" />
                     <div class="info-group">
                         <input type="text" class="setCalc" id="setName1" style="width: 25%" value="My Calc Set">
                         <button type="button" onclick="savecalc1()">Save Calc Set</button>
@@ -628,7 +628,7 @@
                         <select class="move-10hits calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option><option value="6">6 hits</option><option value="7">7 hits</option><option value="8">8 hits</option><option value="9">9 hits</option><option value="10">10 hits</option></select>
                         <select class="move-lastRespRageFist calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
                     </div>
-                    <!--<input class="glaive-rush calc-trigger hide" type="checkbox" id="glaiveR" title="Apply double damage from using Glaive Rush?" />-->
+                    <input class="glaive-rush calc-trigger hide" type="checkbox" id="glaiveR" title="Apply double damage from using Glaive Rush?" />
                     <div class="info-group">
                         <input type="text" class="setCalc" id="setName2" style="width: 25%" value="My Calc Set">
                         <button type="button" onclick="savecalc2()">Save Calc Set</button>

--- a/script_res/ap_calc.css
+++ b/script_res/ap_calc.css
@@ -323,3 +323,9 @@ select.toxic-counter {
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-switch {
     right: 0px;
 }
+
+
+#mainResult {
+    visibility: visible;
+    cursor: pointer;
+}

--- a/script_res/ap_calc.js
+++ b/script_res/ap_calc.js
@@ -447,6 +447,22 @@ $(".status").bind("keyup change", function() {
     }
 });
 
+//sloppy check for Glaive Rush checkbox
+function glaiveRushCheck(divValue) {    //divValue should accept any div class, it's just meant to be a quick way to find which Pokemon it's checking
+    pInfo = $(divValue).closest(".poke-info");
+    pMoves = [pInfo.find(".move1").children("select.move-selector").val(),
+        pInfo.find(".move2").children("select.move-selector").val(),
+        pInfo.find(".move3").children("select.move-selector").val(),
+        pInfo.find(".move4").children("select.move-selector").val()];
+
+    if (pMoves.indexOf("Glaive Rush") != -1)
+        pInfo.find(".glaive-rush").show();
+    else {
+        pInfo.find(".glaive-rush").hide();
+        pInfo.find(".glaive-rush").prop("checked", false);
+    }
+}
+
 // auto-update move details on select
 $(".move-selector").change(function() {
     var moveName = $(this).val();
@@ -496,13 +512,8 @@ $(".move-selector").change(function() {
 
     moveGroupObj.children(".move-z").prop("checked", false);
 
-    //CHANGE HOW THIS WORKS, IT DOESN'T APPEAR FOR SETS AND DISAPPEAR PROPERLY
-    if (moveName == "Glaive Rush")
-        $(this).closest(".poke-info").find(".glaive-rush").show();
-    else {
-        $(this).closest(".poke-info").find(".glaive-rush").hide();
-        $(this).closest(".poke-info").find(".glaive-rush").prop("checked", false);
-    }
+    //SLOPPY WAY OF HANDLING
+    glaiveRushCheck(moveGroupObj);
 });
 
 // auto-update set details on select
@@ -602,6 +613,9 @@ $(".set-selector").change(function() {
 
 function showFormes(formeObj, setName, pokemonName, pokemon) {
     var defaultForme = 0;
+    var gmaxDefaults = ['Venusaur', 'Charizard', 'Blastoise', 'Butterfree', 'Pikachu', 'Meowth', 'Gengar', 'Kingler', 'Lapras', 'Eevee', 'Snorlax', 'Garbodor',
+        'Rillaboom', 'Cinderace', 'Inteleon', 'Orbeetle', 'Coalossal', 'Flapple', 'Sandaconda', 'Toxtricity', 'Centiskorch', 'Hatterene', 'Grimmsnarl',
+        'Alcremie', 'Copperajah', 'Urshifu-Single Strike', 'Urshifu-Rapid Strike'];
 
     if (setName !== 'Blank Set') {
         var set = setdex[pokemonName][setName];
@@ -619,6 +633,11 @@ function showFormes(formeObj, setName, pokemonName, pokemon) {
             }
         }
     }
+
+    if (pokemonName === "Palafin")
+        defaultForme = 1;
+    else if (gen == 8 && !defaultForme && gmaxDefaults.indexOf(pokemonName) != -1)
+        defaultForme = pokedex[pokemonName].formes.indexOf(pokemonName + "-Gmax");
 
     var formeOptions = getSelectOptions(pokemon.formes, false, defaultForme);
     formeObj.children("select").find("option").remove().end().append(formeOptions).change();

--- a/script_res/damage_MASTER.js
+++ b/script_res/damage_MASTER.js
@@ -121,6 +121,9 @@ function buildDescription(description) {
     if (description.isCritical) {
         output += " on a critical hit";
     }
+    if (description.isGlaiveMod) {
+        output += " after using Glaive Rush";
+    }
     if (description.isFriendGuard) {
         output += " with Friend Guard";
     }
@@ -1077,7 +1080,7 @@ function calcBPMods(attacker, defender, field, move, description, ateIzeBoosted,
     var contactOverride = attacker.item === 'Protective Pads' || (attacker.item === 'Punching Glove' && move.isPunch) || attacker.ability === "Long Reach";
 
     //a. Aura Break
-    if (auraActive && auraBreak && !field.isNeutralizingGas) {
+    if (auraActive && auraBreak && !field.isNeutralizingGas && ["Mold Breaker", "Teravolt", "Turboblaze"].indexOf(attacker.ability) == -1) {
         bpMods.push(0x0C00);
         if (isAttackerAura || attacker.ability == "Aura Break") {
             description.attackerAbility = attacker.ability;
@@ -1148,7 +1151,7 @@ function calcBPMods(attacker, defender, field, move, description, ateIzeBoosted,
     }
 
     //f. Fairy Aura, Dark Aura
-    if (auraActive && !auraBreak && !field.isNeutralizingGas) {
+    if (auraActive && !auraBreak && !field.isNeutralizingGas && (gen > 7 || ["Mold Breaker", "Teravolt", "Turboblaze"].indexOf(attacker.ability) == -1)) {
         bpMods.push(0x1548);
         if (isAttackerAura) {
             description.attackerAbility = attacker.ability;
@@ -1611,6 +1614,7 @@ function calcGeneralMods(baseDamage, move, attacker, defender, defAbility, field
     //d. Glaive Rush 2x mod (NEEDS OTHER PARTS TO BE FIXED)
     if (defender.glaiveRushMod) {
         baseDamage = pokeRound(baseDamage * 0x2000 / 0x1000);
+        description.isGlaiveMod = true;
     }
     //e. Crit mod
     if (isCritical) {

--- a/script_res/pokedex.js
+++ b/script_res/pokedex.js
@@ -9405,11 +9405,11 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
 
 var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
   "Venusaur": { "formes": ["Venusaur", "Mega Venusaur"] },
-  "Charizard": { "formes": ["Mega Charizard Y", "Mega Charizard X", "Charizard"] },
+  "Charizard": { "formes": ["Charizard", "Mega Charizard X", "Mega Charizard Y"] },
   "Blastoise": { "formes": ["Blastoise", "Mega Blastoise"] },
   "Butterfree": { "bs": { "sa": 90 } },
-  "Beedrill": { "bs": { "at": 90 }, "formes": ["Mega Beedrill", "Beedrill"] },
-  "Pidgeot": { "bs": { "sp": 101 }, "formes": ["Mega Pidgeot", "Pidgeot"] },
+  "Beedrill": { "bs": { "at": 90 }, "formes": ["Beedrill", "Mega Beedrill"] },
+  "Pidgeot": { "bs": { "sp": 101 }, "formes": ["Pidgeot", "Mega Pidgeot"] },
   "Pikachu": { "bs": { "df": 40, "sd": 50 } },
   "Raichu": { "bs": { "sp": 110 } },
   "Nidoqueen": { "bs": { "at": 92 } },
@@ -9420,22 +9420,22 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
   "Wigglytuff": { "t2": "Fairy", "bs": { "sa": 85 }, "ab": "Competitive" },
   "Vileplume": { "bs": { "sa": 110 } },
   "Poliwrath": { "bs": { "at": 95 } },
-  "Alakazam": { "bs": { "sd": 95 }, "formes": ["Mega Alakazam", "Alakazam"] },
+  "Alakazam": { "bs": { "sd": 95 }, "formes": ["Alakazam", "Mega Alakazam"] },
   "Victreebel": { "bs": { "sd": 70 } },
   "Golem": { "bs": { "at": 120 } },
-  "Slowbro": { "formes": ["Mega Slowbro", "Slowbro"] },
-  "Gengar": { "formes": ["Mega Gengar", "Gengar"] },
-  "Kangaskhan": { "formes": ["Mega Kangaskhan", "Kangaskhan"] },
+  "Slowbro": { "formes": ["Slowbro", "Mega Slowbro"] },
+  "Gengar": { "formes": ["Gengar", "Mega Gengar"] },
+  "Kangaskhan": { "formes": ["Kangaskhan", "Mega Kangaskhan"] },
   "Mr. Mime": { "t2": "Fairy" },
-  "Pinsir": { "formes": ["Mega Pinsir", "Pinsir"] },
-  "Gyarados": { "formes": ["Mega Gyarados", "Gyarados"] },
+  "Pinsir": { "formes": ["Pinsir", "Mega Pinsir"] },
+  "Gyarados": { "formes": ["Gyarados", "Mega Gyarados"] },
   "Aerodactyl": { "formes": ["Aerodactyl", "Mega Aerodactyl"] },
   "Mewtwo": { "formes": ["Mewtwo", "Mega Mewtwo X", "Mega Mewtwo Y"] },
   "Cleffa": { "t1": "Fairy" },
   "Igglybuff": { "t2": "Fairy" },
   "Togepi": { "t1": "Fairy" },
   "Togetic": { "t1": "Fairy" },
-  "Ampharos": { "bs": { "df": 85 }, "formes": ["Mega Ampharos", "Ampharos"] },
+  "Ampharos": { "bs": { "df": 85 }, "formes": ["Ampharos", "Mega Ampharos"] },
   "Bellossom": { "bs": { "df": 95 } },
   "Marill": { "t2": "Fairy" },
   "Azumarill": { "t2": "Fairy", "bs": { "sa": 60 } },
@@ -9453,22 +9453,22 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
   "Beautifly": { "bs": { "sa": 100 } },
   "Ralts": { "t2": "Fairy" },
   "Kirlia": { "t2": "Fairy" },
-  "Gardevoir": { "t2": "Fairy", "formes": ["Mega Gardevoir", "Gardevoir"] },
+  "Gardevoir": { "t2": "Fairy", "formes": ["Gardevoir", "Mega Gardevoir"] },
   "Exploud": { "bs": { "sd": 73 } },
   "Azurill": { "t2": "Fairy" },
   "Sableye": { "formes": ["Sableye", "Mega Sableye"] },
-  "Mawile": { "t2": "Fairy", "formes": ["Mega Mawile", "Mawile"] },
+  "Mawile": { "t2": "Fairy", "formes": ["Mawile", "Mega Mawile"] },
   "Aggron": { "formes": ["Aggron", "Mega Aggron"] },
-  "Medicham": { "formes": ["Mega Medicham", "Medicham"] },
-  "Manectric": { "formes": ["Mega Manectric", "Manectric"] },
+  "Medicham": { "formes": ["Medicham", "Mega Medicham"] },
+  "Manectric": { "formes": ["Manectric", "Mega Manectric"] },
   "Sharpedo": { "formes": ["Sharpedo", "Mega Sharpedo"] },
-  "Camerupt": { "formes": ["Mega Camerupt", "Camerupt"] },
+  "Camerupt": { "formes": ["Camerupt", "Mega Camerupt"] },
   "Altaria": { "formes": ["Altaria", "Mega Altaria"] },
   "Banette": { "formes": ["Banette", "Mega Banette"] },
   "Absol": { "formes": ["Absol", "Mega Absol"] },
   "Glalie": { "formes": ["Glalie", "Mega Glalie"] },
-  "Salamence": { "formes": ["Mega Salamence", "Salamence"] },
-  "Metagross": { "formes": ["Mega Metagross", "Metagross"] },
+  "Salamence": { "formes": ["Salamence", "Mega Salamence"] },
+  "Metagross": { "formes": ["Metagross", "Mega Metagross"] },
   "Latias": { "formes": ["Latias", "Mega Latias"] },
   "Latios": { "formes": ["Latios", "Mega Latios"] },
   "Kyogre": { "formes": ["Primal Kyogre", "Kyogre"] },
@@ -9476,7 +9476,7 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
   "Rayquaza": { "formes": ["Rayquaza", "Mega Rayquaza"] },
   "Staraptor": { "bs": { "sd": 60 } },
   "Roserade": { "bs": { "df": 65 } },
-  "Lopunny": { "formes": ["Mega Lopunny", "Lopunny"] },
+  "Lopunny": { "formes": ["Lopunny", "Mega Lopunny"] },
   "Mime Jr.": { "t2": "Fairy" },
   "Garchomp": { "formes": ["Garchomp", "Mega Garchomp"] },
   "Lucario": { "formes": ["Lucario", "Mega Lucario"] },
@@ -13365,8 +13365,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 90,
     "ab": "Grassy Surge",
     "formes": [
-      "Rillaboom-Gmax",
       "Rillaboom",
+      "Rillaboom-Gmax",
     ]
   },
   "Scorbunny": {
@@ -13410,8 +13410,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 33,
     "ab": "Libero",
     "formes": [
-      "Cinderace-Gmax",
       "Cinderace",
+      "Cinderace-Gmax",
     ]
   },
   "Sobble": {
@@ -13455,8 +13455,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 45.2,
     "ab": "Sniper",
       "formes": [
-      "Inteleon-Gmax",
       "Inteleon",
+      "Inteleon-Gmax",
     ]
   },
   "Blipbug": {
@@ -13499,6 +13499,25 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     },
       "w": 40.8,
       "ab": "Frisk",
+      "formes": [
+          "Orbeetle",
+          "Orbeetle-Gmax",
+      ]
+  },
+  "Orbeetle-Gmax": {
+    "t1": "Bug",
+    "t2": "Psychic",
+    "bs": {
+      "hp": 60,
+      "at": 45,
+      "df": 110,
+      "sa": 80,
+      "sd": 120,
+      "sp": 90
+    },
+      "w": 40.8,
+      "ab": "Frisk",
+      "isAlternateForme": true,
   },
   "Rookidee": {
     "t1": "Flying",
@@ -13774,7 +13793,7 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     },
     "w": 310.5,
     "ab": "Steam Engine",
-    "formes":["Coalossal-Gmax","Coalossal"],
+      "formes": ["Coalossal","Coalossal-Gmax"],
   },
   "Coalossal-Gmax": {
     "t1": "Rock",
@@ -13819,8 +13838,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 1,
       "ab": "Hustle",
       "formes": [
-          "Flapple-Gmax",
           "Flapple",
+          "Flapple-Gmax",
       ]
   },
   "Flapple-Gmax": {
@@ -13898,8 +13917,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 65.5,
       "ab": "Sand Spit",
       "formes": [
-          "Sandaconda-Gmax",
           "Sandaconda",
+          "Sandaconda-Gmax",
       ]
   },
   "Sandaconda-Gmax": {
@@ -13984,8 +14003,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 40,
       "ab": "Punk Rock",
       "formes": [
-          "Toxtricity-Gmax",
           "Toxtricity",
+          "Toxtricity-Gmax",
       ]
   },
   "Toxtricity-Gmax": {
@@ -14032,8 +14051,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 120,
       "ab": "White Smoke",
       "formes": [
-          "Centiskorch-Gmax",
           "Centiskorch",
+          "Centiskorch-Gmax",
       ]
   },
   "Centiskorch-Gmax": {
@@ -14144,8 +14163,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 5.1,
       "ab": "Magic Bounce",
       "formes": [
-          "Hatterene-Gmax",
           "Hatterene",
+          "Hatterene-Gmax",
       ]
   },
   "Hatterene-Gmax": {
@@ -14205,8 +14224,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 61,
       "ab": "Prankster",
       "formes": [
-          "Grimmsnarl-Gmax",
           "Grimmsnarl",
+          "Grimmsnarl-Gmax",
       ]
   },
   "Grimmsnarl-Gmax": {
@@ -14331,8 +14350,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 0.5,
       "ab": "Sweet Veil",
       "formes": [
-          "Alcremie-Gmax",
           "Alcremie",
+          "Alcremie-Gmax",
       ]
   },
   "Alcremie-Gmax": {
@@ -14536,8 +14555,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "w": 650,
       "ab": "Sheer Force",
       "formes": [
-          "Copperajah-Gmax",
           "Copperajah",
+          "Copperajah-Gmax",
       ]
   },
   "Copperajah-Gmax": {
@@ -14792,8 +14811,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "w": 105,
       "ab": "Unseen Fist",
       "formes": [
-          "Urshifu-Single Strike-Gmax",
           "Urshifu-Single Strike",
+          "Urshifu-Single Strike-Gmax",
       ]
   },
   "Urshifu-Single Strike-Gmax": {
@@ -14825,8 +14844,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "w": 105,
       "ab": "Unseen Fist",
       "formes": [
-          "Urshifu-Rapid Strike-Gmax",
           "Urshifu-Rapid Strike",
+          "Urshifu-Rapid Strike-Gmax",
       ]
   },
   "Urshifu-Rapid Strike-Gmax": {
@@ -15080,18 +15099,18 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     },
 
   //GMAX FORMS (save for Galar Pokemon)
-    "Venusaur": { "formes": ["Venusaur-Gmax","Venusaur", "Mega Venusaur"] },
-    "Charizard": { "ab":"Solar Power", "formes": ["Charizard-Gmax", "Charizard", "Mega Charizard Y", "Mega Charizard X"] },
-    "Blastoise": { "formes": ["Blastoise-Gmax", "Blastoise", "Mega Blastoise"] },
-    "Butterfree": { "formes": ["Butterfree-Gmax", "Butterfree"] },
-    "Pikachu": { "formes": ["Pikachu-Gmax", "Pikachu"] },
-    "Meowth": { "formes": ["Meowth-Gmax", "Meowth"] },
-    "Gengar": { "formes": ["Gengar-Gmax", "Gengar", "Mega Gengar"] },
-    "Kingler": { "formes": ["Kingler-Gmax", "Kingler"] },
-    "Lapras": { "formes": ["Lapras-Gmax", "Lapras"] },
-    "Eevee": { "formes": ["Eevee-Gmax", "Eevee"] },
-    "Snorlax": { "formes": ["Snorlax-Gmax", "Snorlax"] },
-    "Garbodor": { "formes": ["Garbodor-Gmax", "Garbodor"] },
+    "Venusaur": { "formes": ["Venusaur", "Mega Venusaur", "Venusaur-Gmax"] },
+    "Charizard": { "ab": "Solar Power", "formes": ["Charizard", "Mega Charizard X", "Mega Charizard Y", "Charizard-Gmax"] },
+    "Blastoise": { "formes": ["Blastoise", "Mega Blastoise", "Blastoise-Gmax"] },
+    "Butterfree": { "formes": ["Butterfree", "Butterfree-Gmax"] },
+    "Pikachu": { "formes": ["Pikachu", "Pikachu-Gmax"] },
+    "Meowth": { "formes": ["Meowth", "Meowth-Gmax"] },
+    "Gengar": { "formes": ["Gengar", "Mega Gengar", "Gengar-Gmax"] },
+    "Kingler": { "formes": ["Kingler", "Kingler-Gmax"] },
+    "Lapras": { "formes": ["Lapras", "Lapras-Gmax"] },
+    "Eevee": { "formes": ["Eevee", "Eevee-Gmax"] },
+    "Snorlax": { "formes": ["Snorlax", "Snorlax-Gmax"] },
+    "Garbodor": { "formes": ["Garbodor", "Garbodor-Gmax"] },
     "Venusaur-Gmax": {
         "t1": "Grass",
         "t2": "Poison",
@@ -15339,10 +15358,10 @@ var POKEDEX_SS = $.extend(true, {}, POKEDEX_SS_NATDEX, {
     "Necrozma-Dawn-Wings": { "formes": null },
     "Necrozma-Dusk-Mane": { "formes": null },});
 
-POKEDEX_SS["Venusaur"].formes = ['Venusaur-Gmax', 'Venusaur'];
-POKEDEX_SS["Charizard"].formes = ['Charizard-Gmax', 'Charizard'];
-POKEDEX_SS["Blastoise"].formes = ['Blastoise-Gmax', 'Blastoise'];
-POKEDEX_SS["Gengar"].formes = ['Gengar-Gmax', 'Gengar'];
+POKEDEX_SS["Venusaur"].formes = ['Venusaur', 'Venusaur-Gmax'];
+POKEDEX_SS["Charizard"].formes = ['Charizard', 'Charizard-Gmax'];
+POKEDEX_SS["Blastoise"].formes = ['Blastoise', 'Blastoise-Gmax'];
+POKEDEX_SS["Gengar"].formes = ['Gengar', 'Gengar-Gmax'];
 
 delete POKEDEX_SS["Rattata-Alola"];
 delete POKEDEX_SS["Raticate-Alola"];

--- a/script_res/setdex_ncp-g9.js
+++ b/script_res/setdex_ncp-g9.js
@@ -228,6 +228,27 @@ var SETDEX_VGC2023 = {
 
     },
     "Talonflame": {
+        "Bulky Tera Ghost Goggles": {
+            "level": 50,
+            "evs": {
+                "hp": 204,
+                "at": 36,
+                "df": 180,
+                "sa": 0,
+                "sd": 4,
+                "sp": 84
+            },
+            "nature": "Jolly",
+            "ability": "Gale Wings",
+            "tera_type": "Ghost",
+            "item": "Safety Goggles",
+            "moves": [
+                "Brave Bird",
+                "Flare Blitz",
+                "Taunt",
+                "Tailwind"
+            ]
+        },
         "Sharp Beak Set": {
             "level": 50,
             "evs": {
@@ -470,7 +491,7 @@ var SETDEX_VGC2023 = {
 
     //},
     "Corviknight": {
-        "Bulk Up Set": {
+        "Bulk Up Tailwind": {
             "level": 50,
             "evs": {
                 "hp": 220,
@@ -482,53 +503,34 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Adamant",
             "ability": "Mirror Armor",
-            "item": "Leftovers",
-            "moves": [
-                "Brave Bird",
-                "Iron Head",
-                "Roost",
-                "Bulk Up"
-            ]
-        },
-        "Tailwind Set": {
-            "level": 50,
-            "evs": {
-                "hp": 252,
-                "at": 4,
-                "df": 52,
-                "sa": 0,
-                "sd": 116,
-                "sp": 20
-            },
-            "nature": "Careful",
-            "ability": "Mirror Armor",
+            "tera_type": "Dragon",
             "item": "Leftovers",
             "moves": [
                 "Brave Bird",
                 "Tailwind",
                 "Roost",
-                "Taunt"
+                "Bulk Up"
             ]
         },
-        "Iron Defense Body Press": {
+        "SoulSur Banded Corv": {
             "level": 50,
             "evs": {
-                "hp": 252,
-                "at": 0,
-                "df": 12,
+                "hp": 116,
+                "at": 252,
+                "df": 0,
                 "sa": 0,
-                "sd": 244,
-                "sp": 0
+                "sd": 0,
+                "sp": 140
             },
-            "nature": "Careful",
+            "nature": "Adamant",
             "ability": "Mirror Armor",
-            "tera_type": "Fighting",
+            "tera_type": "Fire",
             "item": "Leftovers",
             "moves": [
-                "Body Press",
-                "Iron Defense",
-                "Roost",
-                "Tailwind"
+                "Brave Bird",
+                "Tera Blast",
+                "U-turn",
+                "Iron Head"
             ]
         },
 
@@ -941,25 +943,25 @@ var SETDEX_VGC2023 = {
                 "Tidy Up"
             ]
         },
-        "Friend Guard Support": {
+        "Bulky Goggles Support": {
             "level": 50,
             "evs": {
                 "hp": 252,
-                "at": 4,
-                "df": 0,
+                "at": 0,
+                "df": 156,
                 "sa": 0,
-                "sd": 0,
-                "sp": 252
+                "sd": 100,
+                "sp": 0
             },
-            "nature": "Jolly",
+            "nature": "Impish",
             "ability": "Friend Guard",
             "tera_type": "Ghost",
-            "item": "Focus Sash",
+            "item": "Safety Goggles",
             "moves": [
-                "Population Bomb",
-                "Follow Me",
-                "Protect",
-                "Encore"
+                "Super Fang",
+                "Feint",
+                "Beat Up",
+                "Follow Me"
             ]
         },
 
@@ -985,25 +987,25 @@ var SETDEX_VGC2023 = {
                 "Tidy Up"
             ]
         },
-        "Friend Guard Support": {
+        "Bulky Goggles Support": {
             "level": 50,
             "evs": {
                 "hp": 252,
-                "at": 4,
-                "df": 0,
+                "at": 0,
+                "df": 156,
                 "sa": 0,
-                "sd": 0,
-                "sp": 252
+                "sd": 100,
+                "sp": 0
             },
-            "nature": "Jolly",
+            "nature": "Impish",
             "ability": "Friend Guard",
             "tera_type": "Ghost",
-            "item": "Focus Sash",
+            "item": "Safety Goggles",
             "moves": [
-                "Population Bomb",
-                "Follow Me",
-                "Protect",
-                "Encore"
+                "Super Fang",
+                "Feint",
+                "Beat Up",
+                "Follow Me"
             ]
         },
 
@@ -1414,7 +1416,7 @@ var SETDEX_VGC2023 = {
 
     },
     "Garchomp": {
-        "Clear Amulet Swords Dance": {
+        "Clear Amulet 3 Attacks": {
             "level": 50,
             "evs": {
                 "hp": 0,
@@ -1426,34 +1428,34 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Jolly",
             "ability": "Rough Skin",
-            "tera_type": "Ground",
+            "tera_type": "Fire",
             "item": "Clear Amulet",
             "moves": [
-                "Swords Dance",
+                "Stomping Tantrum",
                 "Earthquake",
-                "Rock Slide",
+                "Dragon Claw",
                 "Protect"
             ]
         },
-        "Life Orb Set": {
+        "Scarf Set": {
             "level": 50,
             "evs": {
-                "hp": 0,
-                "at": 252,
-                "df": 0,
+                "hp": 36,
+                "at": 212,
+                "df": 4,
                 "sa": 0,
                 "sd": 4,
                 "sp": 252
             },
-            "nature": "Jolly",
+            "nature": "Adamant",
             "ability": "Rough Skin",
             "tera_type": "Ground",
-            "item": "Life Orb",
+            "item": "Choice Scarf",
             "moves": [
                 "Dragon Claw",
                 "Earthquake",
                 "Rock Slide",
-                "Protect"
+                "Stomping Tantrum"
             ]
         },
 
@@ -1555,6 +1557,27 @@ var SETDEX_VGC2023 = {
 
     },
     "Gyarados": {
+        "Bulky Support Set": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 20,
+                "df": 76,
+                "sa": 0,
+                "sd": 156,
+                "sp": 4
+            },
+            "nature": "Careful",
+            "ability": "Intimdate",
+            "tera_type": "Steel",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Waterfall",
+                "Iron Head",
+                "Taunt",
+                "Thunder Wave"
+            ]
+        },
         "Tera Flying Dragon Dance": {
             "level": 50,
             "evs": {
@@ -2579,7 +2602,7 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Calm",
             "ability": "Shadow Tag",
-            "tera_type": "Dark",
+            "tera_type": "Water",
             "item": "Sitrus Berry",
             "moves": [
                 "Psychic",
@@ -2599,11 +2622,11 @@ var SETDEX_VGC2023 = {
                 "df": 44,
                 "sa": 0,
                 "sd": 36,
-                "sp": 4
+                "sp": 12
             },
             "nature": "Adamant",
             "ability": "Disguise",
-            "tera_type": "Dark",
+            "tera_type": "Fairy",
             "item": "Safety Goggles",
             "moves": [
                 "Play Rough",
@@ -3263,12 +3286,12 @@ var SETDEX_VGC2023 = {
         "Mystic Water Haze": {
             "level": 50,
             "evs": {
-                "hp": 4,
+                "hp": 252,
                 "at": 252,
                 "df": 0,
                 "sa": 0,
                 "sd": 0,
-                "sp": 252
+                "sp": 4
             },
             "nature": "Adamant",
             "ability": "Zero to Hero",
@@ -3365,7 +3388,7 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Careful",
             "ability": "Earth Eater",
-            "tera_type": "Fairy",
+            "tera_type": "Fire",
             "item": "Leftovers",
             "moves": [
                 "Body Press",
@@ -3467,12 +3490,12 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Jolly",
             "ability": "Clear Body",
-            "tera_type": "Ghost",
+            "tera_type": "Steel",
             "item": "Choice Band",
             "moves": [
                 "Dragon Darts",
                 "Tera Blast",
-                "Sucker Punch",
+                "Phantom Force",
                 "U-turn"
             ]
         },
@@ -3661,7 +3684,7 @@ var SETDEX_VGC2023 = {
 
     //},
     "Houndstone": {
-        "Sadn Rush Choice Band": {
+        "Sand Rush Choice Band": {
             "level": 50,
             "evs": {
                 "hp": 0,
@@ -3999,17 +4022,17 @@ var SETDEX_VGC2023 = {
                 "sp": 20
             },
             "nature": "Adamant",
-            "ability": "Inner Focus",
+            "ability": "Multiscale",
             "tera_type": "Normal",
             "item": "Choice Band",
             "moves": [
                 "Extreme Speed",
-                "Dragon Claw",
-                "Earthquake",
-                "Fire Punch"
+                "Outrage",
+                "Stomping Tantrum",
+                "Aerial Ace"
             ]
         },
-        "Tera Normal Assault Vest": {
+        "Tera Flying Assault Vest": {
             "level": 50,
             "evs": {
                 "hp": 252,
@@ -4020,14 +4043,14 @@ var SETDEX_VGC2023 = {
                 "sp": 4
             },
             "nature": "Adamant",
-            "ability": "Inner Focus",
-            "tera_type": "Normal",
+            "ability": "Multiscale",
+            "tera_type": "Flying",
             "item": "Assault Vest",
             "moves": [
                 "Extreme Speed",
                 "Dragon Claw",
-                "Earthquake",
-                "Brick Break"
+                "Stomping Tantrum",
+                "Tera Blast"
             ]
         },
 
@@ -4346,25 +4369,45 @@ var SETDEX_VGC2023 = {
 
     //},
     "Dondozo": {
-        "Tera Dragon Offensive": {
+        "Tera Grass Offensive": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 100,
+                "df": 4,
+                "sa": 0,
+                "sd": 172,
+                "sp": 228
+            },
+            "nature": "Adamant",
+            "ability": "Oblivious",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Tera Blast",
+                "Earthquake",
+                "Wave Crash",
+                "Protect"
+            ]
+        },
+        "Mixed Life Orb Set": {
             "level": 50,
             "evs": {
                 "hp": 0,
-                "at": 252,
+                "at": 4,
                 "df": 0,
-                "sa": 0,
-                "sd": 4,
+                "sa": 252,
+                "sd": 0,
                 "sp": 252
             },
-            "nature": "Adamant",
+            "nature": "Hasty",
             "ability": "Unaware",
-            "tera_type": "Dragon",
-            "item": "Leftovers",
+            "item": "Life Orb",
             "moves": [
-                "Order Up",
-                "Earthquake",
-                "Substitute",
-                "Wave Crash"
+                "Surf",
+                "Wave Crash",
+                "Sleep Talk",
+                "Protect"
             ]
         },
         "Tera Steel Bulky": {
@@ -4442,7 +4485,7 @@ var SETDEX_VGC2023 = {
 
     },
     "Great Tusk": {
-        "Life Orb Set": {
+        "Sash Set": {
             "level": 50,
             "evs": {
                 "hp": 4,
@@ -4453,32 +4496,32 @@ var SETDEX_VGC2023 = {
                 "sp": 252
             },
             "nature": "Jolly",
-            "item": "Life Orb",
+            "item": "Focus Sash",
             "moves": [
                 "Headlong Rush",
                 "Close Combat",
                 "Earthquake",
-                "Protect"
+                "Ice Spinner"
             ]
         },
-        "Assault Vest Set": {
+        "Choice Scarf Set": {
             "level": 50,
             "evs": {
-                "hp": 20,
+                "hp": 0,
                 "at": 252,
-                "df": 68,
+                "df": 0,
                 "sa": 0,
-                "sd": 132,
-                "sp": 36
+                "sd": 4,
+                "sp": 252
             },
-            "nature": "Adamant",
-            "item": "Assault Vest",
+            "nature": "Jolly",
+            "item": "Choice Scarf",
             "tera_type": "Steel",
             "moves": [
                 "Earthquake",
                 "Close Combat",
-                "Iron Head",
-                "Ice Spinner"
+                "Headlong Rush",
+                "Rock Slide"
             ]
         },
 
@@ -4608,7 +4651,7 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Timid",
             "item": "Focus Sash",
-            "tera_type": "Fairy",
+            "tera_type": "Grass",
             "moves": [
                 "Shadow Ball",
                 "Moonblast",
@@ -4631,7 +4674,7 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Modest",
             "item": "Choice Specs",
-            "tera_type": "Steel",
+            "tera_type": "Fairy",
             "moves": [
                 "Shadow Ball",
                 "Moonblast",
@@ -4642,19 +4685,19 @@ var SETDEX_VGC2023 = {
         "Bulky SpAtk Booster Energy": {
             "level": 50,
             "evs": {
-                "hp": 236,
+                "hp": 68,
                 "at": 0,
-                "df": 252,
-                "sa": 4,
-                "sd": 12,
-                "sp": 4
+                "df": 116,
+                "sa": 116,
+                "sd": 4,
+                "sp": 204
             },
             "ivs": {
                 "at": 0,
             },
             "nature": "Modest",
             "item": "Booster Energy",
-            "tera_type": "Grass",
+            "tera_type": "Fairy",
             "moves": [
                 "Shadow Ball",
                 "Moonblast",
@@ -4775,7 +4818,7 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Timid",
             "item": "Booster Energy",
-            "tera_type": "Grass",
+            "tera_type": "Ice",
             "moves": [
                 "Freeze-Dry",
                 "Hydro Pump",
@@ -4783,27 +4826,27 @@ var SETDEX_VGC2023 = {
                 "Protect"
             ]
         },
-        "Specs Set": {
+        "Bulky Speed Booster Set": {
             "level": 50,
             "evs": {
-                "hp": 0,
+                "hp": 44,
                 "at": 0,
-                "df": 0,
-                "sa": 252,
-                "sd": 4,
-                "sp": 252
+                "df": 4,
+                "sa": 228,
+                "sd": 204,
+                "sp": 28
             },
             "ivs": {
                 "at": 0,
             },
             "nature": "Timid",
-            "item": "Choice Specs",
-            "tera_type": "Water",
+            "item": "Booster Energy",
+            "tera_type": "Ghost",
             "moves": [
                 "Freeze-Dry",
                 "Hydro Pump",
                 "Icy Wind",
-                "Chilling Water"
+                "Encore"
             ]
         },
 
@@ -4973,28 +5016,28 @@ var SETDEX_VGC2023 = {
 
     },
     "Baxcalibur": {
-        "Dragon Dance Clear Amulet": {
+        "Standard Clear Amulet": {
             "level": 50,
             "evs": {
-                "hp": 4,
-                "at": 252,
-                "df": 0,
+                "hp": 244,
+                "at": 196,
+                "df": 4,
                 "sa": 0,
-                "sd": 0,
-                "sp": 252
+                "sd": 4,
+                "sp": 60
             },
             "nature": "Adamant",
             "ability": "Thermal Exchange",
-            "tera_type": "Electric",
+            "tera_type": "Poison",
             "item": "Clear Amulet",
             "moves": [
                 "Icicle Crash",
-                "Tera Blast",
-                "Dragon Dance",
+                "Glaive Rush",
+                "Ice Shard",
                 "Protect"
             ]
         },
-        "Swords Dance Life Orb": {
+        "Tera Ground Assault Vest": {
             "level": 50,
             "evs": {
                 "hp": 228,
@@ -5006,13 +5049,13 @@ var SETDEX_VGC2023 = {
             },
             "nature": "Adamant",
             "ability": "Thermal Exchange",
-            "tera_type": "Fire",
-            "item": "Life Orb",
+            "tera_type": "Ground",
+            "item": "Assault Vest",
             "moves": [
                 "Glaive Rush",
                 "Ice Shard",
-                "Swords Dance",
-                "Protect"
+                "Icicle Crash",
+                "Earthquake"
             ]
         },
         "MeLuCa's Loaded Dice Icicle Spear": {
@@ -5039,6 +5082,30 @@ var SETDEX_VGC2023 = {
 
     },
     "Gholdengo": {
+        "Nasty Plot Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 148,
+                "at": 0,
+                "df": 100,
+                "sa": 68,
+                "sd": 4,
+                "sp": 188
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Good as Gold",
+            "tera_type": "Water",
+            "item": "Leftovers",
+            "moves": [
+                "Make It Rain",
+                "Shadow Ball",
+                "Power Gem",
+                "Nasty Plot"
+            ]
+        },
         "Choice Specs Set": {
             "level": 50,
             "evs": {
@@ -5060,7 +5127,7 @@ var SETDEX_VGC2023 = {
                 "Make It Rain",
                 "Shadow Ball",
                 "Power Gem",
-                "Thunderbolt"
+                "Steel Beam"
             ]
         },
         "Life Orb Set": {
@@ -5139,6 +5206,26 @@ var SETDEX_VGC2023 = {
 
     },
     "Ting-Lu": {
+        "Assault Vest Set": {
+            "level": 50,
+            "evs": {
+                "hp": 100,
+                "at": 156,
+                "df": 0,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "tera_type": "Poison",
+            "item": "Assault Vest",
+            "moves": [
+                "Stomping Tantrum",
+                "Payback",
+                "Heavy Slam",
+                "Earthquake"
+            ]
+        },
         "Offensive Sitrus Berry": {
             "level": 50,
             "evs": {
@@ -5181,6 +5268,29 @@ var SETDEX_VGC2023 = {
             "moves": [
                 "Heat Wave",
                 "Snarl",
+                "Dark Pulse",
+                "Overheat"
+            ]
+        },
+        "Life Orb Set": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Water",
+            "item": "Life Orb",
+            "moves": [
+                "Heat Wave",
+                "Tera Blast",
                 "Dark Pulse",
                 "Overheat"
             ]


### PR DESCRIPTION
-Presets for Regulation C have been updated again to better reflect the current metagame
-You can now copy a damage calc by just clicking on the calculation itself
-You can now calculate for the modifier a Pokemon gets after using Glaive Rush via a checkbox below the moves. Only appears if the Pokemon has Glaive Rush as one of its 4 moves.
-Default Formes have been reworked: all Pokemon with their corresponding Mega Stones will default to their Mega forms when loaded into the calc, a list of specific Pokemon with viable Gmax forms will default to their Gmax form in Gen 8, and Palafin will always start in Hero form.